### PR TITLE
UDP support in Socket wrapper and TestApp example

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -129,5 +129,9 @@ public extension Socket {
     static func TCP() throws -> Socket {
         return try Socket(domain: PF_INET, type: SOCK_STREAM, `protocol`: IPPROTO_TCP)
     }
+    
+    static func UDP() throws -> Socket {
+        return try Socket(domain: PF_INET, type: SOCK_DGRAM, `protocol`: IPPROTO_UDP)
+    }
 
 }

--- a/Sources/TCPChannel.swift
+++ b/Sources/TCPChannel.swift
@@ -105,7 +105,7 @@ public class TCPChannel {
 
         if queue == nil {
             let queueAttribute = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, qos, 0)
-            queue = dispatch_queue_create("io.schwa.SwiftIO.UDP.receiveQueue", queueAttribute)
+            queue = dispatch_queue_create("io.schwa.SwiftIO.TCP.receiveQueue", queueAttribute)
         }
 
         dispatch_async(queue) {
@@ -170,7 +170,7 @@ public class TCPChannel {
 
                 if queue == nil {
                     let queueAttribute = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, qos, 0)
-                    queue = dispatch_queue_create("io.schwa.SwiftIO.UDP.receiveQueue", queueAttribute)
+                    queue = dispatch_queue_create("io.schwa.SwiftIO.TCP.receiveQueue", queueAttribute)
                 }
 
                 let channel = dispatch_io_create(DISPATCH_IO_STREAM, socket.descriptor, queue) {

--- a/Sources/UDPChannel.swift
+++ b/Sources/UDPChannel.swift
@@ -36,20 +36,22 @@ import SwiftUtilities
  *  A GCD based UDP listener.
  */
 public class UDPChannel {
-
+    
     public let address: Address
     public let port: UInt16
     public var qos = QOS_CLASS_DEFAULT
-
+    
     public var readHandler: (Datagram -> Void)? = loggingReadHandler
     public var errorHandler: (ErrorType -> Void)? = loggingErrorHandler
-
+    
     private var resumed: Bool = false
     private var receiveQueue: dispatch_queue_t!
     private var sendQueue: dispatch_queue_t!
     private var source: dispatch_source_t!
-    private var socket: Int32!
-
+    private var socket: Socket!
+    
+    // MARK: - Initialization
+    
     public init(address: Address, port: UInt16, readHandler: (Datagram -> Void)? = nil) throws {
         self.address = address
         self.port = port
@@ -57,64 +59,57 @@ public class UDPChannel {
             self.readHandler = readHandler
         }
     }
-
+    
     public convenience init(hostname: String = "0.0.0.0", port: UInt16, family: ProtocolFamily? = nil, readHandler: (Datagram -> Void)? = nil) throws {
         let addresses: [Address] = try Address.addresses(hostname, `protocol`: .UDP, family: family)
         try self.init(address: addresses[0], port: port, readHandler: readHandler)
     }
-
+    
+    // MARK: - Actions
+    
     public func resume() throws {
         debugLog?("Resuming")
-
-        socket = Darwin.socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP)
-        guard socket >= 0 else {
-            throw Error.Generic("socket() failed")
+        
+        do {
+            socket = try Socket.UDP()
         }
-
-        var reuseSocketFlag: Int = 1
-        let result = Darwin.setsockopt(socket, SOL_SOCKET, SO_REUSEADDR, &reuseSocketFlag, socklen_t(sizeof(Int)))
-        guard result == 0 else {
+        catch let error {
             cleanup()
-            throw Error.Generic("setsockopt() failed")
+            errorHandler?(error)
         }
-
+        
+        // set reuse socket option
+        socket.reuse = true
+        
         let queueAttribute = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, qos, 0)
-
-        receiveQueue = dispatch_queue_create("io.schwa.SwiftIO.UDP.receiveQueue", queueAttribute)
-        guard receiveQueue != nil else {
-            cleanup()
-            throw Error.Generic("dispatch_queue_create() failed")
-        }
-
-        sendQueue = dispatch_queue_create("io.schwa.SwiftIO.UDP.sendQueue", queueAttribute)
-        guard sendQueue != nil else {
-            cleanup()
-            throw Error.Generic("dispatch_queue_create() failed")
-        }
-
-        source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, UInt(socket), 0, receiveQueue)
+        
+        try createReceiveQueue(withQueueAttribute: queueAttribute)
+        try createSendQueue(withQueueAttribute: queueAttribute)
+        
+        source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, UInt(socket.descriptor), 0, receiveQueue)
         guard source != nil else {
             cleanup()
             throw Error.Generic("dispatch_source_create() failed")
         }
-
+        
         dispatch_source_set_cancel_handler(source) {
             [weak self] in
             guard let strong_self = self else {
                 return
             }
-
+            
             debugLog?("Cancel handler")
+            
             strong_self.cleanup()
             strong_self.resumed = false
         }
-
+        
         dispatch_source_set_event_handler(source) {
             [weak self] in
             guard let strong_self = self else {
                 return
             }
-
+            
             do {
                 try strong_self.read()
             }
@@ -122,63 +117,68 @@ public class UDPChannel {
                 strong_self.errorHandler?(error)
             }
         }
-
+        
         dispatch_source_set_registration_handler(source) {
             [weak self] in
             guard let strong_self = self else {
                 return
             }
-
-            var address = strong_self.address.to_sockaddr(port: strong_self.port)
-            let result = Darwin.bind(strong_self.socket, &address, socklen_t(sizeof(sockaddr)))
-            guard result == 0 else {
-                strong_self.errorHandler?(Errno(rawValue: errno) ?? Error.Unknown)
+            
+            do {
+                try strong_self.socket.bind(strong_self.address, port: strong_self.port)
+                
+                strong_self.resumed = true
+                
+                debugLog?("Listening on \(strong_self.address)")
+            }
+            catch let error {
+                strong_self.errorHandler?(error)
+                
                 tryElseFatalError() {
                     try strong_self.cancel()
                 }
+                
                 return
             }
-            strong_self.resumed = true
-            debugLog?("Listening on \(strong_self.address)")
         }
-
+        
         dispatch_resume(source)
     }
-
+    
     public func cancel() throws {
         if resumed == true {
             assert(source != nil, "Cancel called with source = nil.")
             dispatch_source_cancel(source)
         }
     }
-
+    
     public func send(data: NSData, address: Address! = nil, port: UInt16, writeHandler: ((Bool,ErrorType?) -> Void)? = loggingWriteHandler) throws {
         let data = DispatchData <Void> (start: data.bytes, count: data.length)
         try send(data, address: address, port: port, writeHandler: writeHandler)
     }
-
+    
     public func send(data: DispatchData <Void>, address: Address! = nil, port: UInt16, writeHandler: ((Bool,ErrorType?) -> Void)? = loggingWriteHandler) throws {
         precondition(receiveQueue != nil, "Cannot send data without a queue")
         precondition(resumed == true, "Cannot send data on unresumed queue")
-
+        
         dispatch_async(sendQueue) {
-
+            
             [weak self] in
             guard let strong_self = self else {
                 return
             }
-
+            
             debugLog?("Send")
-
+            
             let address: Address = address ?? strong_self.address
             var addr = address.to_sockaddr(port: port)
-
+            
             let result = data.createMap() {
                 (_, buffer) in
-                return Darwin.sendto(strong_self.socket, buffer.baseAddress, buffer.count, 0, &addr, socklen_t(addr.sa_len))
+                return Darwin.sendto(strong_self.socket.descriptor, buffer.baseAddress, buffer.count, 0, &addr, socklen_t(addr.sa_len))
             }
-
-
+            
+            
             if result == data.length {
                 writeHandler?(true, nil)
             }
@@ -190,45 +190,71 @@ public class UDPChannel {
             }
         }
     }
-
+    
     internal func read() throws {
-
+        
         let data: NSMutableData! = NSMutableData(length: 4096)
-
+        
         var addressData = Array <Int8> (count: Int(SOCK_MAXADDRLEN), repeatedValue: 0)
         let (result, address, port) = try addressData.withUnsafeMutableBufferPointer() {
             (inout ptr: UnsafeMutableBufferPointer <Int8>) -> (Int, Address?, UInt16?) in
             var addrlen: socklen_t = socklen_t(SOCK_MAXADDRLEN)
-            let result = Darwin.recvfrom(socket, data.mutableBytes, data.length, 0, UnsafeMutablePointer<sockaddr> (ptr.baseAddress), &addrlen)
+            let result = Darwin.recvfrom(socket.descriptor, data.mutableBytes, data.length, 0, UnsafeMutablePointer<sockaddr> (ptr.baseAddress), &addrlen)
             guard result >= 0 else {
                 return (result, nil, nil)
             }
-
+            
             let addr = UnsafeMutablePointer<sockaddr> (ptr.baseAddress).memory
             let address = try Address(addr: addr)
-
+            
             let port = UInt16(networkEndian: addr.port)
             return (result, address, port)
         }
-
+        
         guard result >= 0 else {
             let error = Error.Generic("recvfrom() failed")
             errorHandler?(error)
             throw error
         }
-
+        
         data.length = result
         let datagram = Datagram(from: (address!, port!), timestamp: Timestamp(), data: DispatchData <Void> (buffer: data.toUnsafeBufferPointer()))
         readHandler?(datagram)
     }
-
-    internal func cleanup() {
-        if let socket = self.socket {
-            Darwin.close(socket)
+    
+    // MARK: - GCD
+    
+    private func createReceiveQueue(withQueueAttribute attribute: dispatch_queue_attr_t!) throws {
+        receiveQueue = dispatch_queue_create("io.schwa.SwiftIO.UDP.receiveQueue", attribute)
+        guard receiveQueue != nil else {
+            cleanup()
+            throw Error.Generic("dispatch_queue_create() failed")
         }
-        self.socket = nil
-        self.receiveQueue = nil
-        self.sendQueue = nil
-        self.source = nil
+    }
+    
+    private func createSendQueue(withQueueAttribute attribute: dispatch_queue_attr_t!) throws {
+        sendQueue = dispatch_queue_create("io.schwa.SwiftIO.UDP.sendQueue", attribute)
+        guard sendQueue != nil else {
+            cleanup()
+            throw Error.Generic("dispatch_queue_create() failed")
+        }
+    }
+    
+    // MARK: - Cleanup
+    
+    internal func cleanup() {
+        defer {
+            socket = nil
+            receiveQueue = nil
+            sendQueue = nil
+            source = nil
+        }
+        
+        do {
+            try socket.close()
+        }
+        catch let error {
+            errorHandler?(error)
+        }
     }
 }

--- a/SwiftIO.xcodeproj/project.pbxproj
+++ b/SwiftIO.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		45E80CF81C18BCD5009AAD98 /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E80CF71C18BCD5009AAD98 /* Server.swift */; };
 		45F356421C1A0D920031A299 /* BinaryStreamable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F356411C1A0D920031A299 /* BinaryStreamable.swift */; };
 		45F356431C1A0DAD0031A299 /* BinaryStreamable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F356411C1A0D920031A299 /* BinaryStreamable.swift */; };
+		93D4FCA21C2B8E66002466B9 /* UDPEchoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D4FCA11C2B8E66002466B9 /* UDPEchoViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -202,6 +203,7 @@
 		45E662641C331709004737E1 /* StreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StreamTests.swift; sourceTree = "<group>"; };
 		45E80CF71C18BCD5009AAD98 /* Server.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Server.swift; sourceTree = "<group>"; };
 		45F356411C1A0D920031A299 /* BinaryStreamable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BinaryStreamable.swift; sourceTree = "<group>"; };
+		93D4FCA11C2B8E66002466B9 /* UDPEchoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UDPEchoViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -293,6 +295,7 @@
 				45DD2DAD1B76AD850002994A /* AppDelegate.swift */,
 				45DD2DAF1B76AD850002994A /* EchoViewController.swift */,
 				457847141C178D8B00EF9B35 /* TLVViewController.swift */,
+				93D4FCA11C2B8E66002466B9 /* UDPEchoViewController.swift */,
 				45DAC1421C17BF2E0013C4D6 /* ServerViewController.swift */,
 				45E80CF71C18BCD5009AAD98 /* Server.swift */,
 				457847161C178E5500EF9B35 /* Utilities.swift */,
@@ -556,6 +559,7 @@
 				45E80CF81C18BCD5009AAD98 /* Server.swift in Sources */,
 				45DD2DB01B76AD850002994A /* EchoViewController.swift in Sources */,
 				45DD2DAE1B76AD850002994A /* AppDelegate.swift in Sources */,
+				93D4FCA21C2B8E66002466B9 /* UDPEchoViewController.swift in Sources */,
 				457847171C178E5500EF9B35 /* Utilities.swift in Sources */,
 				45DAC1431C17BF2E0013C4D6 /* ServerViewController.swift in Sources */,
 				457847151C178D8B00EF9B35 /* TLVViewController.swift in Sources */,

--- a/TestApp/Base.lproj/Main.storyboard
+++ b/TestApp/Base.lproj/Main.storyboard
@@ -766,9 +766,7 @@
             <objects>
                 <tabViewController selectedTabViewItemIndex="2" id="iFd-ar-1Bf" sceneMemberID="viewController">
                     <tabViewItems>
-                        <tabViewItem id="wTs-Xs-9Qb"/>
-                        <tabViewItem id="7kn-8i-aid"/>
-                        <tabViewItem id="PQo-va-ukp"/>
+                        <tabViewItem id="FK3-iB-q6k"/>
                     </tabViewItems>
                     <tabView key="tabView" type="noTabsNoBorder" id="MVi-Nx-DPs">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
@@ -777,9 +775,7 @@
                         <tabViewItems/>
                     </tabView>
                     <connections>
-                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="tabItems" id="HpQ-52-wG9"/>
-                        <segue destination="VBF-VT-EtE" kind="relationship" relationship="tabItems" id="wt9-yY-7yi"/>
-                        <segue destination="Sce-QO-a5y" kind="relationship" relationship="tabItems" id="aNb-kX-1qo"/>
+                        <segue destination="PvV-ih-ihm" kind="relationship" relationship="tabItems" id="dVL-zH-jgB"/>
                     </connections>
                 </tabViewController>
                 <customObject id="6l4-bt-AeN" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -1000,6 +996,19 @@
                 <userDefaultsController id="B3v-qF-TBn"/>
             </objects>
             <point key="canvasLocation" x="1195.5" y="646.5"/>
+        </scene>
+        <!--UDP Echo-->
+        <scene sceneID="WnM-SD-0kH">
+            <objects>
+                <viewController title="UDP Echo" id="PvV-ih-ihm" customClass="UDPEchoViewController" customModule="TestApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="xfi-3R-orJ">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="dp4-DT-SR5" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1146" y="1058"/>
         </scene>
     </scenes>
 </document>

--- a/TestApp/Base.lproj/Main.storyboard
+++ b/TestApp/Base.lproj/Main.storyboard
@@ -767,6 +767,9 @@
                 <tabViewController selectedTabViewItemIndex="2" id="iFd-ar-1Bf" sceneMemberID="viewController">
                     <tabViewItems>
                         <tabViewItem id="FK3-iB-q6k"/>
+                        <tabViewItem id="ZHN-g8-qZF"/>
+                        <tabViewItem id="XBL-PE-J8Q"/>
+                        <tabViewItem id="7Pl-8v-Vnx"/>
                     </tabViewItems>
                     <tabView key="tabView" type="noTabsNoBorder" id="MVi-Nx-DPs">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
@@ -776,6 +779,9 @@
                     </tabView>
                     <connections>
                         <segue destination="PvV-ih-ihm" kind="relationship" relationship="tabItems" id="dVL-zH-jgB"/>
+                        <segue destination="Sce-QO-a5y" kind="relationship" relationship="tabItems" id="3Oo-yn-IOK"/>
+                        <segue destination="VBF-VT-EtE" kind="relationship" relationship="tabItems" id="zTG-hP-ZfL"/>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="tabItems" id="CwI-6t-232"/>
                     </connections>
                 </tabViewController>
                 <customObject id="6l4-bt-AeN" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -900,7 +906,7 @@
                 </viewController>
                 <customObject id="owT-cD-Nmq" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="619" y="1029"/>
+            <point key="canvasLocation" x="533" y="1058"/>
         </scene>
         <!--TLV-->
         <scene sceneID="6pR-nP-2SR">
@@ -1004,6 +1010,22 @@
                     <view key="view" id="xfi-3R-orJ">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yMa-US-C1I">
+                                <rect key="frame" x="170" y="133" width="110" height="32"/>
+                                <buttonCell key="cell" type="push" title="Ping Server" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="zde-Lm-reh">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="pingServer:" target="PvV-ih-ihm" id="Adw-CA-dUQ"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="yMa-US-C1I" firstAttribute="centerX" secondItem="xfi-3R-orJ" secondAttribute="centerX" id="GFd-sY-qfj"/>
+                            <constraint firstItem="yMa-US-C1I" firstAttribute="centerY" secondItem="xfi-3R-orJ" secondAttribute="centerY" id="xAO-EJ-zVH"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <customObject id="dp4-DT-SR5" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>

--- a/TestApp/UDPEchoViewController.swift
+++ b/TestApp/UDPEchoViewController.swift
@@ -1,0 +1,27 @@
+//
+//  UDPEchoViewController.swift
+//  SwiftIO
+//
+//  Created by Bart Cone on 12/23/15.
+//  Copyright © 2015 schwa.io. All rights reserved.
+//
+
+import Cocoa
+
+import SwiftIO
+
+class UDPEchoViewController: NSViewController {
+
+    var udp: UDPChannel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        udp = try! UDPChannel(hostname: "localhost", port: 10000) { (data) in
+            print(data)
+        }
+        
+        try! udp.resume()
+    }
+    
+}


### PR DESCRIPTION
I've added UDP support in the socket wrapper, but some functionality in `Socket` isn't supported for UDP. `listen` for example only works for `SOCK_STREAM`. Any thoughts on how you want to handle this? Maybe a type constraint on extension to grant methods like `listen` to certain types?

Also, I updated the dispatch queue names in TCPChannel from:
`io.schwa.SwiftIO.UDP.receiveQueue`
to
`io.schwa.SwiftIO.TCP.receiveQueue`